### PR TITLE
[releng] get rid of monilog repo for build.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,9 @@ jobs:
       # Check-out Monilob4NabLab
       - uses: actions/checkout@v2
 
-      # Check-out monilog (then accessible through $GITHUB_WORKSPACE, so the job can access it)
-      - uses: actions/checkout@v2
-        with:
-          repository: gemoc/monilog
-          path: ./monilog
-
       # Run the build.sh script
       - name: Run build.sh script
-        run: ./build.sh $GITHUB_WORKSPACE/monilog
+        run: ./build.sh
         shell: bash
         env:
           USERNAME: ${{ github.actor }}

--- a/build.sh
+++ b/build.sh
@@ -8,17 +8,10 @@ cd $start/truffle
 mvn clean package --settings $start/.github/workflows/settings.xml
 echo "Done."
 
-#Build monilog
-echo "Building monilog component."
-cd $1
-mvn install
-cd truffle/org.gemoc.monilog.tool
-mvn clean package
-echo "Done."
-
-echo "Moving components to /plugins/fr.cea.nabla.ui.graalvm.p2.main"
+echo "Moving nabla-component to /plugins/fr.cea.nabla.ui.graalvm.p2.main"
 cd $start/plugins/fr.cea.nabla.ui.graalvm.p2.main
 cp $start/truffle/component/nabla-component.jar .
-cp $1/truffle/org.gemoc.monilog.tool/target/monilogger.jar .
+echo "Downloading monilogger.jar to /plugins/fr.cea.nabla.ui.graalvm.p2.main"
+curl -H "Accept: application/zip" -L https://github.com/gemoc/monilog/releases/download/v2.0.0/monilogger.jar -o monilogger.jar
 echo "Done."
 

--- a/features/fr.cea.nabla.ui.graalvm.feature/feature.xml
+++ b/features/fr.cea.nabla.ui.graalvm.feature/feature.xml
@@ -9,6 +9,10 @@
       GraalVM and MoniLog integration plugins for NabLab.
    </description>
 
+   <includes
+         id="org.gemoc.monilog.feature"
+         version="0.0.0"/>
+
    <requires>
       <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.eclipse.equinox.p2.engine"/>


### PR DESCRIPTION
The build.sh script doesn't need monilog git repo address as parameter
anymore. The monilogger.jar file is directly downloaded from
https://github.com/gemoc/monilog/releases/download/v2.0.0/monilogger.jar

Signed-off-by: Axel RICHARD <axel.richard@obeo.fr>